### PR TITLE
fix: prevent text overflow in cards

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,9 +14,10 @@
   margin-bottom: 1.5rem;
 }
 
-.line-clamp-3{
+.line-clamp{
   display: -webkit-box;
   -webkit-line-clamp: 4;
-  -webkit-box-orient: vertical;
+  line-clamp: 4;
+  -webkit-box-orient: vertical;  
   overflow: hidden;
 }

--- a/src/components/AccommodationCard.tsx
+++ b/src/components/AccommodationCard.tsx
@@ -31,7 +31,7 @@ export const AccommodationCard = ({ accommodation }: Props) => (
     >
       <div>
         <Card.Title>{accommodation.name}</Card.Title>
-        <Card.Text style={{ fontSize: "0.9rem" }} className="line-clamp-3">
+        <Card.Text className="line-clamp" style={{ fontSize: "0.9rem" }}>
           {accommodation.description}
         </Card.Text>
       </div>

--- a/src/components/TourCard.tsx
+++ b/src/components/TourCard.tsx
@@ -32,6 +32,7 @@ export const TourCard = ({ tour }: Props) => (
       <div>
         <Card.Title>{tour.name}</Card.Title>
         <Card.Text
+          className="line-clamp"
           style={{
             fontSize: "0.9rem",
           }}


### PR DESCRIPTION
Before:
<img width="1680" height="656" alt="image" src="https://github.com/user-attachments/assets/6e5c4bd1-9243-4eee-b0f3-7bf78a9b1d26" />

After:
<img width="1677" height="623" alt="image" src="https://github.com/user-attachments/assets/7c69cdb2-241e-4dd2-bb9c-d20c8e967e69" />
